### PR TITLE
fix quality

### DIFF
--- a/src/xiaconverter/mainwindow.py
+++ b/src/xiaconverter/mainwindow.py
@@ -335,8 +335,6 @@ class IADialog(Tkinter.Frame):
             return float(3 * 1024 * 1024)
         elif resizeCoeff == 3:
             return float(5 * 1024 * 1024)
-        else:
-            return float(512 * 1024)
 
     def quit(self):
         self.root.destroy()

--- a/src/xiaconverter/xiaconsole.py
+++ b/src/xiaconverter/xiaconsole.py
@@ -35,7 +35,7 @@ class XIAConsole():
         self.kineticLib = kineticLib
         self.sha1Lib = sha1Lib
         self.jqueryLib = jqueryLib
-        self.resize = options['quality']
+        self.resize = int(options['quality']) if options['quality'] in ["0","1","2","3"] else 3
         self.filename = options['input_file']
         self.dirname = options['output_dir']
         self.export_type = options['export_type']
@@ -102,12 +102,10 @@ class XIAConsole():
 
     def defineMaxPixels(self, resizeCoeff):
         if resizeCoeff == 0:
-            return float(512 * 512)
-        elif resizeCoeff == 1:
             return float(1024 * 1024)
+        elif resizeCoeff == 1:
+            return float(2 * 1024 * 1024)
         elif resizeCoeff == 2:
             return float(3 * 1024 * 1024)
         elif resizeCoeff == 3:
             return float(5 * 1024 * 1024)
-        else:
-            return float(512 * 1024)


### PR DESCRIPTION
For the console version:
* Default maxNumPixels was set to 512*1024 whereas it should have been set to the same value than quality 3.
* quality is a string argument and was compared to an integer, so maxNumPixels was always set to the (as we just see) wrong value of 512*1024
* Values weren't the same as in the GUI version

For the GUI version:
* Default case for quality isn't necessary

By the way, it could be a good thing to match quality levels to what being said in the GUI: (1, 2, 3, 4) instead of (0, 1, 2, 3). What's your opinion on that ?
I can do it before you merge this pull request.